### PR TITLE
Adjust referrer logic in fixture creation to be more real world

### DIFF
--- a/generate-fixtures.js
+++ b/generate-fixtures.js
@@ -52,24 +52,40 @@ fs.writeFile(outfile, JSON.stringify(events, null, 2), function (err) {
 
 function newFakeSession (length) {
   const sessionId = uuid.v4()
-  const isMobileSession = Math.random() > 0.66
+  const isMobileSession = sometimes(33)
   const timestamp = Date.now() - randomInRange(0, 600000)
-  return Array.from({ length }).map(function () {
-    return {
+  const sessionReferrer = sometimes(25)
+    ? randomReferrer()
+    : ''
+  let previousHref
+  return Array.from({ length }).map(function (el, index) {
+    const href = randomPage()
+    const result = {
       type: 'PAGEVIEW',
-      href: randomPage(),
+      href: href,
       title: 'Page Title',
-      referrer: Math.random() > 0.75 ? randomReferrer() : '',
+      referrer: index === 0
+        ? sessionReferrer
+        : previousHref,
       pageload: randomInRange(400, 1200),
       isMobile: isMobileSession,
       timestamp: new Date(timestamp + randomInRange(0, 1000)),
       sessionId: sessionId
     }
+    previousHref = href
+    return result
   })
 }
 
 function randomInRange (lower, upper) {
+  if (crypto.randomInt) {
+    return crypto.randomInt(lower, upper + 1)
+  }
   return _.sample(_.range(lower, upper + 1))
+}
+
+function sometimes (percentage) {
+  return randomInRange(1, 100) <= percentage
 }
 
 function randomPage () {


### PR DESCRIPTION
This follows up on #5 and adjusts the logic which is used to create random referrers a little. This will have no effect on the results being returned by the stats functions used in Offen (as it always just  looks at the first event within a session for referrers), but it aligns the fixtures better with what the functions are being passed in the real world.

In addition, use `crypto.randomInt` if available as it seems to be whole lot faster then `_.sample(_.range(a, b))`